### PR TITLE
Update matml Docker to reflect latest MatGL with DGL backend

### DIFF
--- a/docker/Dockerfile.matgl
+++ b/docker/Dockerfile.matgl
@@ -3,5 +3,5 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 ENV DGLBACKEND=pytorch
 ENV MATGL_BACKEND=DGL
 
-RUN uv pip install --system dgl==2.1.0 torchdata==0.7.1
+RUN uv pip install --system dgl==2.1.0 torch==2.2.0 torchdata==0.7.1
 RUN uv pip install --system matgl

--- a/docker/Dockerfile.matgl
+++ b/docker/Dockerfile.matgl
@@ -1,6 +1,7 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 
 ENV DGLBACKEND=pytorch
+ENV MATGL_BACKEND=DGL
 
-RUN uv pip install --system matgl==1.2.6
-RUN uv pip install --system dgl==2.1.0 torch==2.2.0 torchdata==0.7.1
+RUN uv pip install --system dgl==2.1.0 torchdata==0.7.1
+RUN uv pip install --system matgl

--- a/docker/Dockerfile.matgl.cuda
+++ b/docker/Dockerfile.matgl.cuda
@@ -1,9 +1,9 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 
 ENV DGLBACKEND=pytorch
+ENV MATGL_BACKEND=DGL
 
-RUN uv pip install torch==2.2.0 --index-url https://download.pytorch.org/whl/cu121 --system
-RUN uv pip install torchdata==0.7.1 --system
 RUN uv pip install dgl -f https://data.dgl.ai/wheels/cu121/repo.html --system
 RUN uv pip install dglgo -f https://data.dgl.ai/wheels-test/repo.html --system
-RUN uv pip install matgl==1.2.6 --system
+RUN uv pip install torchdata==0.7.1 --system
+RUN uv pip install matgl --system

--- a/docker/Dockerfile.matgl.cuda
+++ b/docker/Dockerfile.matgl.cuda
@@ -3,7 +3,8 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 ENV DGLBACKEND=pytorch
 ENV MATGL_BACKEND=DGL
 
+
 RUN uv pip install dgl -f https://data.dgl.ai/wheels/cu121/repo.html --system
 RUN uv pip install dglgo -f https://data.dgl.ai/wheels-test/repo.html --system
-RUN uv pip install torchdata==0.7.1 --system
+RUN uv pip install torch==2.2.0 torchdata==0.7.1 --system
 RUN uv pip install matgl --system

--- a/docker/Dockerfile.matml
+++ b/docker/Dockerfile.matml
@@ -2,6 +2,7 @@
 FROM materialsvirtuallab/lammps_gnnp:latest
 
 ENV DGLBACKEND=pytorch
+ENV MATGL_BACKEND=DGL
 
-RUN uv pip install --system matgl==1.2.6 matcalc==0.3.3 matpes
+RUN uv pip install --system matgl matcalc matpes
 RUN uv pip install --system dgl==2.1.0 torch==2.2.0 torchdata==0.7.1

--- a/docker/Dockerfile.matml
+++ b/docker/Dockerfile.matml
@@ -4,5 +4,4 @@ FROM materialsvirtuallab/lammps_gnnp:latest
 ENV DGLBACKEND=pytorch
 ENV MATGL_BACKEND=DGL
 
-RUN uv pip install --system matgl matcalc matpes
-RUN uv pip install --system dgl==2.1.0 torch==2.2.0 torchdata==0.7.1
+RUN uv pip install --system matgl matcalc matpes "numpy<2" dgl==2.1.0 torch==2.2.0 torchdata==0.7.1


### PR DESCRIPTION
## Summary

Major changes:

- Removed pin for older matgl. `uv` now resolves to latest matgl. Only installs `DGL` backend. 

- Fixes materialyzeai/matgl#731

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
